### PR TITLE
Use a symlinking magic to fix path

### DIFF
--- a/tib-demo/tib_containers
+++ b/tib-demo/tib_containers
@@ -1,0 +1,1 @@
+../tib_containers/


### PR DESCRIPTION
We add a simlink to `tib_containers`, so that the website (hopefully) works for both the github.io and the custom domain.